### PR TITLE
feat: add Unocss settings page

### DIFF
--- a/src/main/kotlin/me/rerere/unocssintellij/Unocss.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/Unocss.kt
@@ -2,13 +2,11 @@ package me.rerere.unocssintellij
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.google.gson.JsonParser
 import com.intellij.javascript.nodejs.packageJson.NodeInstalledPackageFinder
 import com.intellij.lang.javascript.buildTools.npm.PackageJsonUtil
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import kotlinx.serialization.json.Json
 import me.rerere.unocssintellij.util.toLocalVirtualFile
 
 object Unocss {

--- a/src/main/kotlin/me/rerere/unocssintellij/UnocssProcess.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/UnocssProcess.kt
@@ -137,6 +137,8 @@ class UnocssProcess(project: Project, context: VirtualFile) : Disposable {
                 continuation.resumeWithException(
                     RuntimeException(jsonObject["error"]?.asString ?: "unknown error")
                 )
+            } else if (!jsonObject.has("result")) {
+                continuation.resume(Unit as R)
             } else {
                 val res = Unocss.GSON.fromJson(jsonObject["result"].toString(), object : TypeToken<R>() {})
                 continuation.resume(res)

--- a/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssAttributeCompletionContributor.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssAttributeCompletionContributor.kt
@@ -23,9 +23,9 @@ import com.intellij.psi.xml.XmlAttribute
 import com.intellij.psi.xml.XmlElementType
 import com.intellij.util.ProcessingContext
 import com.intellij.util.ui.ColorIcon
-import com.intellij.xml.util.HtmlUtil
 import me.rerere.unocssintellij.UnocssService
 import me.rerere.unocssintellij.marker.SVGIcon
+import me.rerere.unocssintellij.settings.UnocssSettingsState
 import me.rerere.unocssintellij.util.isClassAttribute
 import me.rerere.unocssintellij.util.parseColors
 import me.rerere.unocssintellij.util.parseIcons
@@ -52,8 +52,8 @@ object UnocssAttributeCompletionProvider : CompletionProvider<CompletionParamete
         context: ProcessingContext,
         result: CompletionResultSet
     ) {
+        if (!UnocssSettingsState.instance.enable) return
         val element = parameters.position
-        println("addCompletions: $element")
 
         var unocssPrefix = ""
         val completionPrefix = extractTypingPrefix(result.prefixMatcher.prefix)
@@ -76,14 +76,14 @@ object UnocssAttributeCompletionProvider : CompletionProvider<CompletionParamete
         val service = project.service<UnocssService>()
 
         ApplicationUtil.runWithCheckCanceled({
-            service.getCompletion(parameters.originalFile.virtualFile, prefix, prefix.length)
+            val maxItems = UnocssSettingsState.instance.maxItems
+            service.getCompletion(parameters.originalFile.virtualFile, prefix, maxItems = maxItems)
         }, ProgressManager.getInstance().progressIndicator).forEach { suggestion ->
             val className = if (unocssPrefix.isNotBlank()) {
                 suggestion.className.substring(unocssPrefix.length + 1)
             } else {
                 suggestion.className
             }
-            println("suggestion: $className")
 
             val colors = parseColors(suggestion.css)
             val icon = parseIcons(suggestion.css)

--- a/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssCSSCompletionContributor.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssCSSCompletionContributor.kt
@@ -11,6 +11,7 @@ import com.intellij.util.ProcessingContext
 import com.intellij.util.ui.ColorIcon
 import me.rerere.unocssintellij.UnocssService
 import me.rerere.unocssintellij.marker.SVGIcon
+import me.rerere.unocssintellij.settings.UnocssSettingsState
 import me.rerere.unocssintellij.util.parseColors
 import me.rerere.unocssintellij.util.parseIcons
 import me.rerere.unocssintellij.util.trimCss
@@ -31,6 +32,7 @@ object UnocssCSSTermListCompletionProvider : CompletionProvider<CompletionParame
         context: ProcessingContext,
         result: CompletionResultSet
     ) {
+        if (!UnocssSettingsState.instance.enable) return
         val element = parameters.position
 
         val project = element.project
@@ -39,7 +41,8 @@ object UnocssCSSTermListCompletionProvider : CompletionProvider<CompletionParame
         val prefix = result.prefixMatcher.prefix
 
         ApplicationUtil.runWithCheckCanceled({
-            service.getCompletion(parameters.originalFile.virtualFile, prefix, prefix.length)
+            val maxItems = UnocssSettingsState.instance.maxItems
+            service.getCompletion(parameters.originalFile.virtualFile, prefix, maxItems = maxItems)
         }, ProgressManager.getInstance().progressIndicator).forEach { suggestion ->
             val colors = parseColors(suggestion.css)
             val icon = parseIcons(suggestion.css)

--- a/src/main/kotlin/me/rerere/unocssintellij/inspection/UnocssXmlSuppressionProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/inspection/UnocssXmlSuppressionProvider.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.util.elementType
 import com.intellij.psi.xml.XmlElementType
 import me.rerere.unocssintellij.model.UnocssResolveMeta
+import me.rerere.unocssintellij.settings.UnocssSettingsState
 
 /**
  * For suppressing unknown attribute inspection
@@ -16,7 +17,7 @@ class UnocssXmlSuppressionProvider : XmlSuppressionProvider() {
         private const val HTML_UNKNOWN_ATTRIBUTE = "HtmlUnknownAttribute"
     }
 
-    override fun isProviderAvailable(file: PsiFile) = true
+    override fun isProviderAvailable(file: PsiFile) = UnocssSettingsState.instance.enable
 
     override fun suppressForFile(element: PsiElement, inspectionId: String) {
     }
@@ -25,6 +26,7 @@ class UnocssXmlSuppressionProvider : XmlSuppressionProvider() {
     }
 
     override fun isSuppressedFor(element: PsiElement, inspectionId: String): Boolean {
+        if (!UnocssSettingsState.instance.enable) return false
         if (element.elementType == XmlElementType.XML_NAME && inspectionId == HTML_UNKNOWN_ATTRIBUTE) {
             return suppressForUnknownAttribute(element)
         }

--- a/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssCssLineMarkerProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssCssLineMarkerProvider.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.util.elementType
 import me.rerere.unocssintellij.model.UnocssResolveMeta
 
 class UnocssCssLineMarkerProvider : UnocssLineMarkerProvider() {
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+    override fun doGetLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         // match when use Directives transformer
         if (element.elementType == CssElementTypes.CSS_IDENT
             || element.elementType == CssElementTypes.CSS_STRING_TOKEN) {

--- a/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssHtmlLineMarkerProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssHtmlLineMarkerProvider.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.xml.XmlElementType
 import me.rerere.unocssintellij.model.UnocssResolveMeta
 
 open class UnocssHtmlLineMarkerProvider : UnocssLineMarkerProvider() {
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+    override fun doGetLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         // match with "Valueless" attributify preset
         if (element.elementType == XmlElementType.XML_NAME) {
             return getFromXmlName(element)

--- a/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssJsLineMarkerProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssJsLineMarkerProvider.kt
@@ -12,8 +12,8 @@ import me.rerere.unocssintellij.model.UnocssResolveMeta
  * For JSX/TSX Support
  */
 class UnocssJsLineMarkerProvider : UnocssHtmlLineMarkerProvider() {
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
-        val lineMarkerInfo = super.getLineMarkerInfo(element)
+    override fun doGetLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        val lineMarkerInfo = super.doGetLineMarkerInfo(element)
         if (lineMarkerInfo != null) return lineMarkerInfo
 
         val attrValue: String = (if (element is JSLiteralExpression && element.isStringLiteral) {

--- a/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssLineMarkerProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssLineMarkerProvider.kt
@@ -3,12 +3,21 @@ package me.rerere.unocssintellij.marker
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
 import com.intellij.util.ui.ColorIcon
 import me.rerere.unocssintellij.model.UnocssResolveMeta
+import me.rerere.unocssintellij.settings.UnocssSettingsState
 import me.rerere.unocssintellij.util.parseColors
 import me.rerere.unocssintellij.util.parseIcons
 
 abstract class UnocssLineMarkerProvider : LineMarkerProvider {
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        if (!UnocssSettingsState.instance.enable) return null
+        return doGetLineMarkerInfo(element)
+    }
+
+    abstract fun doGetLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>?
 
     protected fun getLineMarkerInfo(meta: UnocssResolveMeta): LineMarkerInfo<*>? {
         val css = meta.resolveCss()?.css ?: return null

--- a/src/main/kotlin/me/rerere/unocssintellij/rpc/RpcCommand.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/rpc/RpcCommand.kt
@@ -8,15 +8,21 @@ data class RpcCommand<T>(
 
 enum class RpcAction(val key: String) {
     ResolveConfig("resolveConfig"),
+    UpdateSettings("updateSettings"),
     GetComplete("getComplete"),
     ResolveCss("resolveCSS"),
     ResolveCssByOffset("resolveCSSByOffset"),
     ResolveAnnotations("resolveAnnotations"),
 }
 
+data class UpdateSettingsCommandData(
+    val matchType: String
+)
+
 data class GetCompleteCommandData(
     val content: String,
-    val cursor: Int = content.length
+    val cursor: Int = content.length,
+    val maxItems: Int,
 )
 
 data class SuggestionItem(

--- a/src/main/kotlin/me/rerere/unocssintellij/settings/UnocssSettingsComponent.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/settings/UnocssSettingsComponent.kt
@@ -1,0 +1,73 @@
+package me.rerere.unocssintellij.settings
+
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.*
+
+class UnocssSettingsComponent {
+
+    val panel: DialogPanel
+    private val settings = UnocssSettingsState.instance
+    private lateinit var enableCheckbox: Cell<JBCheckBox>
+    private lateinit var previewRemToPxCheckbox: Cell<JBCheckBox>
+
+    init {
+        panel = panel {
+            row {
+                enableCheckbox = checkBox("Enable unocss").bindSelected(settings::enable)
+            }
+
+            group("Documentation") {
+                row {
+                    previewRemToPxCheckbox = checkBox("Rem to px Preview")
+                        .bindSelected(settings::remToPxPreview)
+                        .comment("Enable/disable rem to px preview in hover document")
+                }
+                row("Rem To Px Ratio") {
+                    spinner(0.0..100.0, 1.0)
+                        .bindValue(settings::remToPxRatio)
+                        .comment("Radio of rem to px, used in rem to px preview")
+                        .validationOnInput {
+                            val num = it.value.toString().toDoubleOrNull()
+                            if (num == null) error("Invalid number") else null
+                        }
+                        .errorOnApply("Invalid radio number") { it.value.toString().toDoubleOrNull() == null }
+                }.enabledIf(previewRemToPxCheckbox.selected)
+            }.visibleIf(enableCheckbox.selected)
+
+            group("Autocomplete") {
+                buttonsGroup {
+                    row("Match Type") {
+                        radioButton("Prefix", "prefix")
+                        radioButton("Fuzzy", "fuzzy")
+                    }
+                }.bind(settings::matchType)
+
+                row("Max Items") {
+                    intTextField(1..1000, 1)
+                        .bindIntText(settings::maxItems)
+                        .comment("The maximum number of items to show in autocomplete")
+                        .validationOnInput {
+                            val num = it.text.toIntOrNull()
+                            if (num == null) error("Invalid number") else null
+                        }
+                        .errorOnApply("Invalid number") { it.text.toIntOrNull() == null }
+                }
+            }.visibleIf(enableCheckbox.selected)
+        }
+    }
+
+    val isModified get() = panel.isModified()
+
+    fun reset() {
+        panel.reset()
+    }
+
+    fun apply() {
+        panel.apply()
+    }
+
+    override fun toString(): String {
+        return settings.toString()
+    }
+}

--- a/src/main/kotlin/me/rerere/unocssintellij/settings/UnocssSettingsConfigurable.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/settings/UnocssSettingsConfigurable.kt
@@ -1,0 +1,45 @@
+package me.rerere.unocssintellij.settings
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
+import me.rerere.unocssintellij.UnocssService
+import javax.swing.JComponent
+
+class UnocssSettingsConfigurable(private val project: Project) : Configurable {
+
+    private var mySettingsComponent: UnocssSettingsComponent? = null
+
+    override fun getDisplayName(): String {
+        return "Unocss"
+    }
+
+    override fun createComponent(): JComponent {
+        mySettingsComponent = UnocssSettingsComponent()
+        return mySettingsComponent!!.panel
+    }
+
+    override fun isModified(): Boolean {
+        val component = mySettingsComponent ?: return false
+        return component.isModified
+    }
+
+    override fun apply() {
+        val component = mySettingsComponent ?: return
+        val matchTypeBefore = UnocssSettingsState.instance.matchType
+        component.apply()
+        val matchTypeAfter = UnocssSettingsState.instance.matchType
+        if (matchTypeBefore != matchTypeAfter) {
+            project.service<UnocssService>().updateSettings()
+        }
+    }
+
+    override fun reset() {
+        val component = mySettingsComponent ?: return
+        component.reset()
+    }
+
+    override fun disposeUIResources() {
+        mySettingsComponent = null
+    }
+}

--- a/src/main/kotlin/me/rerere/unocssintellij/settings/UnocssSettingsState.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/settings/UnocssSettingsState.kt
@@ -1,0 +1,37 @@
+package me.rerere.unocssintellij.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@State(
+    name = "me.rerere.unocssintellij.settings.UnocssSettingsState",
+    storages = [Storage("UnocssIntellij.xml")]
+)
+class UnocssSettingsState : PersistentStateComponent<UnocssSettingsState> {
+
+    companion object {
+        val instance: UnocssSettingsState
+            get() = ApplicationManager.getApplication().service<UnocssSettingsState>()
+    }
+
+    var enable = true
+    // var colorPreview = true
+    var matchType = "prefix"
+    var maxItems = 50
+    var remToPxPreview = true
+    var remToPxRatio = 16.0
+
+    override fun getState(): UnocssSettingsState = this
+
+    override fun loadState(state: UnocssSettingsState) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    override fun toString(): String {
+        return "UnocssSettingsState(enable=$enable, matchType='$matchType', maxItems=$maxItems, remToPxPreview=$remToPxPreview, remToPxRatio=$remToPxRatio)"
+    }
+}

--- a/src/main/kotlin/me/rerere/unocssintellij/status/UnocssStatusBarFactory.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/status/UnocssStatusBarFactory.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.wm.StatusBarWidgetFactory
 import com.intellij.openapi.wm.impl.status.EditorBasedStatusBarPopup
 import kotlinx.coroutines.runBlocking
 import me.rerere.unocssintellij.UnocssService
+import me.rerere.unocssintellij.settings.UnocssSettingsState
 
 class UnocssStatusBarFactory : StatusBarWidgetFactory {
     companion object {
@@ -60,6 +61,8 @@ class UnocssStatusPop(project: Project) : EditorBasedStatusBarPopup(project, fal
     }
 
     override fun getWidgetState(file: VirtualFile?): WidgetState {
+        if (!UnocssSettingsState.instance.enable) return WidgetState.HIDDEN
+
         val text: String = if (file == null) {
             "Unocss"
         } else {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -91,6 +91,16 @@
         <lang.inspectionSuppressor
                 language="JavaScript"
                 implementationClass="me.rerere.unocssintellij.inspection.UnocssXmlSuppressionProvider"/>
+
+        <applicationService serviceImplementation="me.rerere.unocssintellij.settings.UnocssSettingsState" />
+        <projectConfigurable
+            parentId="tools"
+            instance="me.rerere.unocssintellij.settings.UnocssSettingsConfigurable"
+            id="me.rerere.unocssintellij.settings.UnocssSettingsConfigurable"
+            displayName="Unocss"
+            nonDefaultProject="true"
+        />
+
     </extensions>
 
     <projectListeners>


### PR DESCRIPTION
Add Unocss settings page and related setting logic.

looks like:
<img width="1050" alt="image" src="https://github.com/re-ovo/unocss-intellij/assets/28809242/b908301f-bcea-40e5-95b7-ce9e53ba7281">

known issues:
- After toggle enable unocss, opened files have to be reopen to apply changes