### PR TITLE
fix: autocompletion not work in some cases

### DIFF
--- a/src/main/kotlin/me/rerere/unocssintellij/UnocssProcess.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/UnocssProcess.kt
@@ -33,9 +33,8 @@ class UnocssProcess(project: Project, context: VirtualFile) : Disposable {
 
     init {
         println("[UnoProcess] Starting UnoProcess")
-        val interpreter = NodeJsInterpreterManager.getInstance(project).interpreter ?: run {
-            error("Node.js interpreter not found")
-        }
+        val interpreter = NodeJsInterpreterManager.getInstance(project).interpreter
+            ?: error("Node.js interpreter not found")
         val configurator = NodeCommandLineConfigurator.find(interpreter)
         val directory = JSLanguageServiceUtil.getPluginDirectory(Unocss::class.java, "unojs")
             ?: error("Plugin directory not found")

--- a/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssAttributeCompletionContributor.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssAttributeCompletionContributor.kt
@@ -1,37 +1,20 @@
 package me.rerere.unocssintellij.completion
 
-import com.intellij.codeInsight.AutoPopupController
-import com.intellij.codeInsight.completion.*
-import com.intellij.codeInsight.completion.impl.CompletionServiceImpl
-import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
-import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.codeInsight.lookup.LookupManager
-import com.intellij.codeInsight.lookup.impl.LookupImpl
-import com.intellij.openapi.application.ex.ApplicationUtil
-import com.intellij.openapi.components.service
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.EditorModificationUtil
-import com.intellij.openapi.progress.ProgressManager
-import com.intellij.openapi.project.Project
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.intellij.psi.xml.XmlAttribute
 import com.intellij.psi.xml.XmlElementType
 import com.intellij.refactoring.suggested.startOffset
-import com.intellij.util.ProcessingContext
-import com.intellij.util.ui.ColorIcon
-import me.rerere.unocssintellij.UnocssService
-import me.rerere.unocssintellij.marker.SVGIcon
-import me.rerere.unocssintellij.settings.UnocssSettingsState
+import me.rerere.unocssintellij.rpc.SuggestionItem
 import me.rerere.unocssintellij.util.isClassAttribute
-import me.rerere.unocssintellij.util.parseColors
-import me.rerere.unocssintellij.util.parseIcons
-import me.rerere.unocssintellij.util.trimCss
 
-private val matchVariantGroupPrefixRE = Regex("^(.*\\s)?(.*)\\(([^)]*)$")
+private val matchVariantGroupPrefixRE = Regex("^(?:.*\\s)?(.*)\\(([^)]*)$")
 
 class UnocssAttributeCompletionContributor : CompletionContributor() {
     init {
@@ -50,18 +33,14 @@ class UnocssAttributeCompletionContributor : CompletionContributor() {
     }
 }
 
-object UnocssAttributeCompletionProvider : CompletionProvider<CompletionParameters>() {
-    override fun addCompletions(
-        parameters: CompletionParameters,
-        context: ProcessingContext,
-        result: CompletionResultSet
-    ) {
-        if (!UnocssSettingsState.instance.enable) return
+object UnocssAttributeCompletionProvider : UnocssCompletionProvider() {
+
+    override fun resolvePrefix(parameters: CompletionParameters, result: CompletionResultSet): PrefixHolder? {
         val element = parameters.position
 
         val xmlAttrName = if (element.elementType == XmlElementType.XML_ATTRIBUTE_VALUE_TOKEN) {
             val xmlAttributeEle = PsiTreeUtil.getParentOfType(element, XmlAttribute::class.java, false)
-                ?: return
+                ?: return null
             xmlAttributeEle.firstChild.text
         } else ""
 
@@ -69,47 +48,12 @@ object UnocssAttributeCompletionProvider : CompletionProvider<CompletionParamete
         // so we may use the substring of element.text to keep the behavior of
         // class value and other attribute values consistent
         val prefixToResolve = element.text.substring(0, parameters.offset - element.startOffset)
-        val (typingPrefix, prefixToSuggest) = resolvePrefix(element, prefixToResolve, xmlAttrName) ?: return
-
-        val project = element.project
-        val service = project.service<UnocssService>()
-
-        val resultSet = result.withPrefixMatcher(typingPrefix)
-        ApplicationUtil.runWithCheckCanceled({
-            val maxItems = UnocssSettingsState.instance.maxItems
-            service.getCompletion(parameters.originalFile.virtualFile, prefixToSuggest, maxItems = maxItems)
-        }, ProgressManager.getInstance().progressIndicator).forEach { suggestion ->
-            val className = if (typingPrefix != prefixToSuggest) {
-                suggestion.className.substring(prefixToSuggest.length - typingPrefix.length)
-            } else {
-                suggestion.className
-            }
-
-            val colors = parseColors(suggestion.css)
-            val icon = parseIcons(suggestion.css)
-            resultSet.addElement(
-                LookupElementBuilder
-                    .create(className)
-                    .withLookupString(suggestion.className)
-                    .withPresentableText(className)
-                    .withTypeText("Unocss")
-                    .withIcon(
-                        if (colors.isNotEmpty()) {
-                            ColorIcon(16, colors.first())
-                        } else if (icon != null) {
-                            SVGIcon(icon)
-                        } else null
-                    )
-                    .withTailText(trimCss(suggestion.css), true)
-            )
-        }
-
-        result.restartCompletionOnAnyPrefixChange()
+        return resolvePrefix(element, prefixToResolve, xmlAttrName)
     }
 
     private fun resolvePrefix(element: PsiElement, prefix: String, attrName: String): PrefixHolder? {
         if (element.elementType != XmlElementType.XML_ATTRIBUTE_VALUE_TOKEN) {
-            return PrefixHolder(prefix, prefix)
+            return PrefixHolder(prefix)
         }
 
         // attributify value
@@ -140,10 +84,10 @@ object UnocssAttributeCompletionProvider : CompletionProvider<CompletionParamete
             }
         } else {
             val matchResult = matchVariantGroupPrefixRE.find(prefix) ?: return null
-            val variants = matchResult.groupValues[2]
+            val variants = matchResult.groupValues[1]
             // use last().trim() to help manually trigger code completion (e.g. via keymap)
             // the variant group will be used as prefix to query suggestions
-            val token = matchResult.groupValues[3].split(" ").last().trim()
+            val token = matchResult.groupValues[2].split(" ").last().trim()
 
             typingPrefix = token
             prefixToSuggest = "${variants.substring(variants.lastIndexOf(":") + 1)}$token"
@@ -152,47 +96,13 @@ object UnocssAttributeCompletionProvider : CompletionProvider<CompletionParamete
         return PrefixHolder(typingPrefix, prefixToSuggest)
     }
 
-    private data class PrefixHolder(
-        /**
-         * typing prefix is the prefix that user is typing, used to let intellij to match with suggestion
-         */
-        val typingPrefix: String,
-        /**
-         * prefix to suggest is the prefix that will be used to query suggestions
-         * usually has the same value as typing prefix, but
-         *
-         * - when using variant group, it will be added with variant prefix
-         * - when using attributify presets, it will be added with html attribute name as prefix
-         *
-         * It will be fine to ignore variant prefix like `hover:` when querying suggestions
-         */
-        val prefixToSuggest: String
-    )
-}
-
-// Make auto popup work when typing '-'
-// https://github.com/JetBrains/intellij-community/blob/4d5322af326084873e16cfafd0239a1713a52adc/plugins/terminal/src/org/jetbrains/plugins/terminal/exp/TerminalCompletionAutoPopupHandler.kt#L19
-class TypedHandler : TypedHandlerDelegate() {
-    override fun checkAutoPopup(charTyped: Char, project: Project, editor: Editor, file: PsiFile): Result {
-        if (!project.service<UnocssService>().isProcessRunning()) return Result.CONTINUE
-
-        val phase = CompletionServiceImpl.getCompletionPhase()
-        val lookup = LookupManager.getActiveLookup(editor)
-        if (lookup is LookupImpl) {
-            if (editor.selectionModel.hasSelection()) {
-                lookup.performGuardedChange { EditorModificationUtil.deleteSelectedText(editor) }
-            }
-            return Result.STOP
-        }
-
-        if (Character.isLetterOrDigit(charTyped) || charTyped == '-') {
-            if (phase is CompletionPhase.EmptyAutoPopup && phase.allowsSkippingNewAutoPopup(editor, charTyped)) {
-                return Result.CONTINUE
-            }
-            AutoPopupController.getInstance(project).scheduleAutoPopup(editor)
-            return Result.STOP
-        }
-
-        return Result.CONTINUE
+    override fun resolveSuggestionClassName(
+        typingPrefix: String,
+        prefixToSuggest: String,
+        suggestion: SuggestionItem
+    ) = if (typingPrefix != prefixToSuggest) {
+        suggestion.className.substring(prefixToSuggest.length - typingPrefix.length)
+    } else {
+        suggestion.className
     }
 }

--- a/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssCompletionProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssCompletionProvider.kt
@@ -1,0 +1,124 @@
+package me.rerere.unocssintellij.completion
+
+import com.intellij.codeInsight.AutoPopupController
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionPhase
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.impl.CompletionServiceImpl
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.codeInsight.lookup.LookupManager
+import com.intellij.codeInsight.lookup.impl.LookupImpl
+import com.intellij.openapi.application.ex.ApplicationUtil
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorModificationUtil
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.util.ProcessingContext
+import com.intellij.util.ui.ColorIcon
+import me.rerere.unocssintellij.UnocssService
+import me.rerere.unocssintellij.marker.SVGIcon
+import me.rerere.unocssintellij.rpc.SuggestionItem
+import me.rerere.unocssintellij.settings.UnocssSettingsState
+import me.rerere.unocssintellij.util.parseColors
+import me.rerere.unocssintellij.util.parseIcons
+import me.rerere.unocssintellij.util.trimCss
+
+data class PrefixHolder(
+    /**
+     * typing prefix is the prefix that user is typing, used to let intellij to match with suggestion
+     */
+    val typingPrefix: String,
+    /**
+     * prefix to suggest is the prefix that will be used to query suggestions
+     * usually has the same value as typing prefix, but
+     *
+     * - when using variant group, it will be added with variant prefix
+     * - when using attributify presets, it will be added with html attribute name as prefix
+     *
+     * It will be fine to ignore variant prefix like `hover:` when querying suggestions
+     */
+    val prefixToSuggest: String
+) {
+    constructor(prefix: String) : this(prefix, prefix)
+}
+
+abstract class UnocssCompletionProvider : CompletionProvider<CompletionParameters>() {
+
+    abstract fun resolvePrefix(parameters: CompletionParameters, result: CompletionResultSet): PrefixHolder?
+
+    open fun resolveSuggestionClassName(
+        typingPrefix: String,
+        prefixToSuggest: String,
+        suggestion: SuggestionItem
+    ): String = suggestion.className
+
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        val (typingPrefix, prefixToSuggest) = resolvePrefix(parameters, result) ?: return
+        val completionResult = result.withPrefixMatcher(typingPrefix)
+
+        val project = parameters.position.project
+        val service = project.service<UnocssService>()
+        ApplicationUtil.runWithCheckCanceled({
+            val maxItems = UnocssSettingsState.instance.maxItems
+            service.getCompletion(parameters.originalFile.virtualFile, prefixToSuggest, maxItems = maxItems)
+        }, ProgressManager.getInstance().progressIndicator).forEach { suggestion ->
+
+            val className = resolveSuggestionClassName(typingPrefix, prefixToSuggest, suggestion)
+
+            val colors = parseColors(suggestion.css)
+            val icon = parseIcons(suggestion.css)
+            completionResult.addElement(
+                LookupElementBuilder
+                    .create(className)
+                    .withLookupString(suggestion.className)
+                    .withPresentableText(className)
+                    .withTypeText("Unocss")
+                    .withIcon(
+                        if (colors.isNotEmpty()) {
+                            ColorIcon(16, colors.first())
+                        } else if (icon != null) {
+                            SVGIcon(icon)
+                        } else null
+                    )
+                    .withTailText(trimCss(suggestion.css), true)
+            )
+        }
+
+        result.restartCompletionOnAnyPrefixChange()
+    }
+}
+
+// Make auto popup work when typing '-'
+// https://github.com/JetBrains/intellij-community/blob/4d5322af326084873e16cfafd0239a1713a52adc/plugins/terminal/src/org/jetbrains/plugins/terminal/exp/TerminalCompletionAutoPopupHandler.kt#L19
+class TypedHandler : TypedHandlerDelegate() {
+    override fun checkAutoPopup(charTyped: Char, project: Project, editor: Editor, file: PsiFile): Result {
+        if (!project.service<UnocssService>().isProcessRunning()) return Result.CONTINUE
+
+        val phase = CompletionServiceImpl.getCompletionPhase()
+        val lookup = LookupManager.getActiveLookup(editor)
+        if (lookup is LookupImpl) {
+            if (editor.selectionModel.hasSelection()) {
+                lookup.performGuardedChange { EditorModificationUtil.deleteSelectedText(editor) }
+            }
+            return Result.STOP
+        }
+
+        if (Character.isLetterOrDigit(charTyped) || charTyped == '-') {
+            if (phase is CompletionPhase.EmptyAutoPopup && phase.allowsSkippingNewAutoPopup(editor, charTyped)) {
+                return Result.CONTINUE
+            }
+            AutoPopupController.getInstance(project).scheduleAutoPopup(editor)
+            return Result.STOP
+        }
+
+        return Result.CONTINUE
+    }
+}

--- a/src/main/kotlin/me/rerere/unocssintellij/highlighting/UnocssAttributeExternalAnnotator.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/highlighting/UnocssAttributeExternalAnnotator.kt
@@ -18,20 +18,16 @@ import me.rerere.unocssintellij.settings.UnocssSettingsState
 import me.rerere.unocssintellij.util.MatchedPosition
 import me.rerere.unocssintellij.util.getMatchedPositions
 
-data class UnocssState(val enabled: Boolean = true)
-
 data class UnocssInitInfo(
     val project: Project,
     val service: UnocssService,
     val psiFile: PsiFile,
     val fileContent: String,
-    val state: UnocssState,
 )
 
 data class UnocssAnnotationResult(
     val code: String,
-    val state: UnocssState,
-    val annotations: List<MatchedPosition>
+    val annotations: List<MatchedPosition>,
 )
 
 /**
@@ -54,7 +50,7 @@ class UnocssAttributeExternalAnnotator : ExternalAnnotator<UnocssInitInfo, Unocs
             }
 
             val unocssService = project.service<UnocssService>()
-            return UnocssInitInfo(project, unocssService, psiFile, fileContent, UnocssState())
+            return UnocssInitInfo(project, unocssService, psiFile, fileContent)
         }
         return null
     }
@@ -73,7 +69,7 @@ class UnocssAttributeExternalAnnotator : ExternalAnnotator<UnocssInitInfo, Unocs
         } ?: return null
 
         val matchedPositions = getMatchedPositions(code, resolveResult)
-        return UnocssAnnotationResult(code, UnocssState(), matchedPositions)
+        return UnocssAnnotationResult(code, matchedPositions)
     }
 
     override fun apply(file: PsiFile, annotationResult: UnocssAnnotationResult?, holder: AnnotationHolder) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,6 +47,7 @@
         />
         <completion.contributor
             language="JavaScript"
+            order="before jsx-attr, before tsx-attr, before VueCompletionContributor, before VuexCompletionContributor"
             implementationClass="me.rerere.unocssintellij.completion.UnocssAttributeCompletionContributor"
         />
         <completion.contributor

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,11 +52,11 @@
         <completion.contributor
             language="CSS"
             implementationClass="me.rerere.unocssintellij.completion.UnocssCSSCompletionContributor" />
+        <typedHandler implementation="me.rerere.unocssintellij.completion.TypedHandler" order="first"/>
 
         <!-- 文档提示 -->
         <platform.backend.documentation.targetProvider
                 implementation="me.rerere.unocssintellij.documentation.UnocssDocumentTargetProvider" />
-        <typedHandler implementation="me.rerere.unocssintellij.completion.TypedHandler"/>
 
         <!-- 图标 -->
         <codeInsight.lineMarkerProvider


### PR DESCRIPTION
Fixed autocomplete issues in most cases

**Known issues**
- typing string property in v-bind class object not trigger autocomplete popup (very weird 🤯)
   workaround: manually trigger code completion (e.g. via keymap)