### PR TITLE
refactor: rearrange config management and more kotlin style code

### DIFF
--- a/src/main/kotlin/me/rerere/unocssintellij/Unocss.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/Unocss.kt
@@ -9,9 +9,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import me.rerere.unocssintellij.util.toLocalVirtualFile
 
-val UNOCSS_PRESET_ATTRIBUTIFY = "@unocss/preset-attributify"
-val UNOCSS_TRANSFORMER_DIRECTIVES = "@unocss/transformer-directives"
-
 object Unocss {
     // Logger
     val Logger = logger<Unocss>()

--- a/src/main/kotlin/me/rerere/unocssintellij/UnocssConfigManager.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/UnocssConfigManager.kt
@@ -33,7 +33,7 @@ object UnocssConfigManager {
         this.config = config
 
         println("[UnoCSS] Presets: ${config.presets.joinToString { it.name }}")
-        println("[UnoCSS] Transformers: ${config.transformers.joinToString { it.name }}")
+        println("[UnoCSS] Transformers: ${config.transformers?.joinToString { it.name }}")
 
         updateThemeKeys()
     }

--- a/src/main/kotlin/me/rerere/unocssintellij/UnocssConfigManager.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/UnocssConfigManager.kt
@@ -1,0 +1,77 @@
+package me.rerere.unocssintellij
+
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import me.rerere.unocssintellij.rpc.ResolveConfigResult
+
+object UnocssConfigManager {
+
+    object Transformers {
+        const val ATTRIBUTIFY_JSX = "@unocss/transformer-attributify-jsx"
+
+        const val DIRECTIVES = "@unocss/transformer-directives"
+    }
+
+    object Presets {
+        const val ATTRIBUTIFY = "@unocss/preset-attributify"
+    }
+
+    var config: ResolveConfigResult? = null
+        private set
+
+    val theme: JsonObject get() = config?.theme ?: JsonNull.INSTANCE.asJsonObject
+
+    private var flatTheme: MutableMap<String, String> = hashMapOf()
+
+    val themeKeys: Set<String>
+        get() = flatTheme.keys
+
+    val themeEntries: Set<Map.Entry<String, String>>
+        get() = flatTheme.entries
+
+    fun updateConfig(config: ResolveConfigResult) {
+        this.config = config
+
+        println("[UnoCSS] Presets: ${config.presets.joinToString { it.name }}")
+        println("[UnoCSS] Transformers: ${config.transformers.joinToString { it.name }}")
+
+        updateThemeKeys()
+    }
+
+    val hasPresetAttributify: Boolean
+        get() = hasPreset(Presets.ATTRIBUTIFY)
+
+    val hasTransformerDirective: Boolean
+        get() = hasTransformer(Transformers.DIRECTIVES)
+
+    fun hasPreset(preset: String): Boolean {
+        return config?.presets?.any { it.name == preset } ?: false
+    }
+
+    fun hasTransformer(transformer: String): Boolean {
+        return config?.transformers?.any { it.name == transformer } ?: false
+    }
+
+    private fun updateThemeKeys() {
+        fun getKeys(element: JsonObject, result: MutableMap<String, String>, prefix: String = "") {
+            element.keySet().forEach { key ->
+                val value = element.get(key)
+                if (value.isJsonObject) {
+                    getKeys(value.asJsonObject, result, "$prefix$key.")
+                } else if (value.isJsonPrimitive) {
+                    result["$prefix$key"] = value.asString
+                }
+            }
+        }
+
+        config?.let {
+            flatTheme.clear()
+            getKeys(it.theme, flatTheme)
+            println("[UnoCSS] Parsed ${themeKeys.size} theme keys")
+        }
+    }
+
+    fun getThemeValue(key: String): String? {
+        return flatTheme[key]
+    }
+}

--- a/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssCssCompletionContributor.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssCssCompletionContributor.kt
@@ -6,11 +6,15 @@ import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.PsiElement
-import com.intellij.psi.css.impl.*
+import com.intellij.psi.css.impl.CssAtRuleImpl
+import com.intellij.psi.css.impl.CssDeclarationImpl
+import com.intellij.psi.css.impl.CssElementTypes
+import com.intellij.psi.css.impl.CssRulesetImpl
 import com.intellij.psi.filters.ElementFilter
 import com.intellij.psi.filters.position.FilterPattern
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.util.parentOfTypes
 import me.rerere.unocssintellij.references.UnoConfigPsiHelper
 
 class UnocssCssTermCompletionContributor : CompletionContributor() {
@@ -41,20 +45,20 @@ class UnocssCssTermCompletionContributor : CompletionContributor() {
             if (!psiElement.isValid) {
                 return false
             }
-            if (PsiTreeUtil.getParentOfType(psiElement, CssRulesetImpl::class.java) == null) {
+            if (psiElement.parentOfType<CssRulesetImpl>() == null) {
                 return false
             }
             // skip
             if (psiElement.elementType === CssElementTypes.CSS_IDENT
-                && psiElement.parent is CssDeclarationImpl) {
+                && psiElement.parent is CssDeclarationImpl
+            ) {
                 return false
             }
-            val cssDeclaration: PsiElement = PsiTreeUtil.getParentOfType(
-                psiElement,
+            val cssDeclaration: PsiElement = psiElement.parentOfTypes(
                 // for apply variable
-                CssDeclarationImpl::class.java,
+                CssDeclarationImpl::class,
                 // for @apply
-                CssAtRuleImpl::class.java
+                CssAtRuleImpl::class
             ) ?: return false
 
             val propKey = cssDeclaration.firstChild

--- a/src/main/kotlin/me/rerere/unocssintellij/documentation/UnocssDocument.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/documentation/UnocssDocument.kt
@@ -9,8 +9,8 @@ import com.intellij.psi.css.impl.CssAtRuleImpl
 import com.intellij.psi.css.impl.CssElementType
 import com.intellij.psi.css.impl.CssElementTypes
 import com.intellij.psi.impl.source.xml.XmlAttributeValueImpl
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentOfTypes
 import com.intellij.psi.xml.XmlElementType
 import com.intellij.psi.xml.XmlTokenType
 import com.intellij.refactoring.suggested.startOffset
@@ -48,9 +48,8 @@ class UnocssDocumentTargetProvider : DocumentationTargetProvider {
                 elementType !is CssElementType
             )
         } else {
-            val attributeValueEle = PsiTreeUtil.getParentOfType(
-                element,
-                XmlAttributeValueImpl::class.java, JSXmlAttributeValueImpl::class.java
+            val attributeValueEle = element.parentOfTypes(
+                XmlAttributeValueImpl::class, JSXmlAttributeValueImpl::class
             ) ?: return targets
 
             val isLiteralValue = elementType == XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN || isJsString(element)

--- a/src/main/kotlin/me/rerere/unocssintellij/documentation/UnocssDocumentationTargets.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/documentation/UnocssDocumentationTargets.kt
@@ -23,6 +23,7 @@ import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.refactoring.suggested.createSmartPointer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import me.rerere.unocssintellij.UnocssConfigManager
 import me.rerere.unocssintellij.UnocssService
 import me.rerere.unocssintellij.references.UnoConfigPsiHelper
 import me.rerere.unocssintellij.rpc.ResolveCSSResult
@@ -145,8 +146,7 @@ class UnocssThemeConfigDocumentTarget(
                 return@doc null
             }
 
-            val service = targetElement.project.service<UnocssService>()
-            val configValue = service.getThemeValue(themeConfigPath) ?: return@doc null
+            val configValue = UnocssConfigManager.getThemeValue(themeConfigPath) ?: return@doc null
 
             DocumentationResult.documentation(buildString {
                 append(DocumentationMarkup.DEFINITION_START)

--- a/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssCssLineMarkerProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssCssLineMarkerProvider.kt
@@ -1,13 +1,12 @@
 package me.rerere.unocssintellij.marker
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
 import com.intellij.psi.css.impl.CssElementTypes
 import com.intellij.psi.util.elementType
 import com.intellij.util.ui.ColorIcon
-import me.rerere.unocssintellij.UnocssService
+import me.rerere.unocssintellij.UnocssConfigManager
 import me.rerere.unocssintellij.model.UnocssResolveMeta
 import me.rerere.unocssintellij.references.UnoConfigPsiHelper
 import me.rerere.unocssintellij.util.parseHexColor
@@ -16,7 +15,8 @@ class UnocssCssLineMarkerProvider : UnocssLineMarkerProvider() {
     override fun doGetLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         // match when use Directives transformer
         if (element.elementType == CssElementTypes.CSS_IDENT
-            || element.elementType == CssElementTypes.CSS_STRING_TOKEN) {
+            || element.elementType == CssElementTypes.CSS_STRING_TOKEN
+        ) {
             return getFromCssIdent(element)
         }
 
@@ -34,8 +34,7 @@ class UnocssCssLineMarkerProvider : UnocssLineMarkerProvider() {
     }
 
     private fun getLineMarkerInfoFromConfigFile(element: PsiElement, themeArg: String): LineMarkerInfo<*>? {
-        val service = element.project.service<UnocssService>()
-        val configValue = service.getThemeValue(themeArg) ?: return null
+        val configValue = UnocssConfigManager.getThemeValue(themeArg) ?: return null
         // color icon
         val colorValue = parseHexColor(configValue) ?: return null
         return LineMarkerInfo(

--- a/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssHtmlLineMarkerProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssHtmlLineMarkerProvider.kt
@@ -2,8 +2,8 @@ package me.rerere.unocssintellij.marker
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentOfType
 import com.intellij.psi.xml.XmlAttributeValue
 import com.intellij.psi.xml.XmlElementType
 import me.rerere.unocssintellij.model.UnocssResolveMeta
@@ -25,12 +25,12 @@ open class UnocssHtmlLineMarkerProvider : UnocssLineMarkerProvider() {
     private fun getFromXmlName(element: PsiElement): LineMarkerInfo<*>? {
         // only attribute name
         return if (element.nextSibling == null) {
-             getLineMarkerInfo(UnocssResolveMeta(element, element.text, null))
+            getLineMarkerInfo(UnocssResolveMeta(element, element.text, null))
         } else null
     }
 
     private fun getFromXmlAttributeValueToken(element: PsiElement): LineMarkerInfo<*>? {
-        val xmlAttrValueEle = PsiTreeUtil.getParentOfType(element, XmlAttributeValue::class.java) ?: return null
+        val xmlAttrValueEle = element.parentOfType<XmlAttributeValue>() ?: return null
         val xmlName = xmlAttrValueEle.parent.firstChild.text
 
         return getLineMarkerInfo(UnocssResolveMeta(element, xmlName, element.text))

--- a/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssJsLineMarkerProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/marker/UnocssJsLineMarkerProvider.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.lang.javascript.psi.JSLiteralExpression
 import com.intellij.lang.javascript.psi.JSProperty
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
 import com.intellij.psi.xml.XmlAttributeValue
 import me.rerere.unocssintellij.model.UnocssResolveMeta
 
@@ -24,7 +24,7 @@ class UnocssJsLineMarkerProvider : UnocssHtmlLineMarkerProvider() {
             element.firstChild.text
         } else null) ?: return null
 
-        val xmlAttrValueEle = PsiTreeUtil.getParentOfType(element, XmlAttributeValue::class.java) ?: return null
+        val xmlAttrValueEle = element.parentOfType<XmlAttributeValue>() ?: return null
         val xmlName = xmlAttrValueEle.parent.firstChild.text
 
         // Both JSLiteralExpression's first child and JSProperty's first child are LeafPsiElement

--- a/src/main/kotlin/me/rerere/unocssintellij/references/UnoConfigPsiHelper.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/references/UnoConfigPsiHelper.kt
@@ -10,20 +10,22 @@ import com.intellij.psi.css.impl.CssAtRuleImpl
 import com.intellij.psi.css.impl.CssFunctionImpl
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
 import me.rerere.unocssintellij.Unocss
+import me.rerere.unocssintellij.util.childOfTypeDeeply
+import me.rerere.unocssintellij.util.childrenOfTypeDeeply
 
 object UnoConfigPsiHelper {
     val screenPrefixes = setOf("lt-", "at-")
     val defaultApplyVariable = setOf("--at-apply", "--uno-apply", "--uno")
 
     fun inCssThemeFunction(element: PsiElement): Boolean {
-        val parent = PsiTreeUtil.getParentOfType(element, CssFunctionImpl::class.java)
+        val parent = element.parentOfType<CssFunctionImpl>()
         return parent != null && parent.name == "theme"
     }
 
     fun inScreenDirective(element: PsiElement): Boolean {
-        val parent = PsiTreeUtil.getParentOfType(element, CssAtRuleImpl::class.java)
+        val parent = element.parentOfType<CssAtRuleImpl>()
         return parent != null && parent.name == "@screen"
     }
 
@@ -40,8 +42,8 @@ object UnoConfigPsiHelper {
     fun findThemeConfig(element: PsiElement): JSElement? {
         val configFile = findUnoConfigFile(element)
 
-        PsiTreeUtil.findChildrenOfType(configFile, JSObjectLiteralExpression::class.java)
-            .forEach { jsObjectLiteralExpression ->
+        configFile?.childrenOfTypeDeeply<JSObjectLiteralExpression>()
+            ?.forEach { jsObjectLiteralExpression ->
                 val themeProperty = jsObjectLiteralExpression.findProperty("theme")
                 if (themeProperty != null) {
 
@@ -49,7 +51,7 @@ object UnoConfigPsiHelper {
                     if (themeProperty.value is JSReferenceExpression) {
                         val reference = themeProperty.value as JSReferenceExpression
                         val resolved = reference.resolve()
-                        val objectLiteral = PsiTreeUtil.findChildOfType(resolved, JSObjectLiteralExpression::class.java)
+                        val objectLiteral = resolved?.childOfTypeDeeply<JSObjectLiteralExpression>()
                         if (objectLiteral != null) {
                             return objectLiteral
                         }

--- a/src/main/kotlin/me/rerere/unocssintellij/rpc/RpcCommand.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/rpc/RpcCommand.kt
@@ -20,7 +20,7 @@ enum class RpcAction(val key: String) {
 
 data class ResolveConfigResult(
     val presets: List<ResolveConfigResultPresetItem>,
-    val transformers: List<ResolveConfigResultTransformerItem>,
+    val transformers: List<ResolveConfigResultTransformerItem>?,
     val theme: JsonObject
 )
 

--- a/src/main/kotlin/me/rerere/unocssintellij/util/PsiHelper.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/util/PsiHelper.kt
@@ -1,5 +1,6 @@
 package me.rerere.unocssintellij.util
 
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.lang.javascript.psi.JSLiteralExpression
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.PsiElement
@@ -26,6 +27,14 @@ fun buildDummyDivTag(vararg attributes: Pair<String, String?>) = buildString {
         }
     }
     append(" >")
+}
+
+inline fun <reified T : PsiElement> PsiElement.childrenOfTypeDeeply(): Collection<T> {
+    return PsiTreeUtil.findChildrenOfType(this, T::class.java)
+}
+
+inline fun <reified T : PsiElement> PsiElement.childOfTypeDeeply(): T? {
+    return PsiTreeUtil.findChildOfType(this, T::class.java)
 }
 
 private val jsStringMatcher = PlatformPatterns


### PR DESCRIPTION
- Extract Unocss configs into separated file for better management
- Replace `PsiTreeUtil` with kotlin extension function