### PR TITLE
fix: :bug: documentation not working in attribute

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -60,7 +60,7 @@
 
         <!-- 文档提示 -->
         <platform.backend.documentation.targetProvider
-                implementation="me.rerere.unocssintellij.documentation.UnocssDocumentTargetProvider"/>
+                implementation="me.rerere.unocssintellij.documentation.UnocssDocumentTargetProvider" order="first"/>
 
         <!-- 图标 -->
         <codeInsight.lineMarkerProvider


### PR DESCRIPTION
### Before:

---

The hint for the attribute is `Custom Vue component property` .

![image](https://github.com/re-ovo/unocss-intellij/assets/13103906/8e37329b-8181-4f21-a126-5f392c646e3c)

### After

---

Show correct documentation generated by Unocss.

![image](https://github.com/re-ovo/unocss-intellij/assets/13103906/388ad830-c388-416f-8e52-baa4f064c8f9)

### Reason

---

After debugging, I found that there are multiple `targetPointer` here, but only the first one is used, which is [WebSymbolDocumentationTarget](https://github.com/JetBrains/intellij-community/blob/233/platform/webSymbols/src/com/intellij/webSymbols/documentation/WebSymbolDocumentationTarget.kt) , so changing the order of `UnocssDocumentTargetProvider` can solve this problem.

![image](https://github.com/re-ovo/unocss-intellij/assets/13103906/f514c920-f220-4704-8621-897b28c2bf64)
