### PR TITLE
fix: get rid of `Slow operations are prohibited on EDT` since build 233

### DIFF
--- a/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssCompletionProvider.kt
+++ b/src/main/kotlin/me/rerere/unocssintellij/completion/UnocssCompletionProvider.kt
@@ -20,6 +20,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.util.ProcessingContext
 import com.intellij.util.ui.ColorIcon
+import kotlinx.coroutines.runBlocking
 import me.rerere.unocssintellij.UnocssService
 import me.rerere.unocssintellij.marker.SVGIcon
 import me.rerere.unocssintellij.rpc.SuggestionItem
@@ -81,11 +82,13 @@ abstract class UnocssCompletionProvider : CompletionProvider<CompletionParameter
         val service = project.service<UnocssService>()
         ApplicationUtil.runWithCheckCanceled({
             val maxItems = UnocssSettingsState.instance.maxItems
-            service.getCompletion(
-                ctx = parameters.originalFile.virtualFile,
-                prefix = prefixToSuggest,
-                maxItems = maxItems
-            )
+            runBlocking {
+                service.getCompletion(
+                    ctx = parameters.originalFile.virtualFile,
+                    prefix = prefixToSuggest,
+                    maxItems = maxItems
+                )
+            }
         }, ProgressManager.getInstance().progressIndicator).forEach { suggestion ->
 
             val className = resolveSuggestionClassName(typingPrefix, prefixToSuggest, suggestion)


### PR DESCRIPTION
Since IntelliJ 2023.3 Threading Model Changes, IDE may complain about `Slow operations are prohibited on EDT` error.
Let's get rid of it by switching some read actions to coroutines.